### PR TITLE
build: bump to v2-periphery@1.0.1

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,6 +1,4 @@
 @sablier/v2-core/=lib/v2-core/src/
-@sablier/v2-periphery/=lib/v2-periphery/src/
 @sablier/v2-periphery-test/=lib/v2-periphery/test/
+@sablier/v2-periphery/=lib/v2-periphery/src/
 forge-std/=lib/forge-std/src/
-permit2/=lib/v2-periphery/lib/permit2/src/
-


### PR DESCRIPTION
This PR also removes the local `permit2` remapping.