### PR TITLE
fix: inconsistency between the example and the docs for stream creators

### DIFF
--- a/v2/core/LockupDynamicCurvesCreator.sol
+++ b/v2/core/LockupDynamicCurvesCreator.sol
@@ -36,6 +36,7 @@ contract LockupDynamicCurvesCreator {
         params.totalAmount = totalAmount; // Total amount is the amount inclusive of all fees
         params.asset = DAI; // The streaming asset
         params.cancelable = true; // Whether the stream will be cancelable or not
+        params.transferable = true; // Whether the stream will be transferable or not
         params.broker = Broker(address(0), ud60x18(0)); // Optional parameter left undefined
 
         // Declare a single-size segment to match the curve shape

--- a/v2/core/LockupDynamicStreamCreator.sol
+++ b/v2/core/LockupDynamicStreamCreator.sol
@@ -34,6 +34,7 @@ contract LockupDynamicStreamCreator {
         params.totalAmount = uint128(totalAmount); // Total amount is the amount inclusive of all fees
         params.asset = DAI; // The streaming asset
         params.cancelable = true; // Whether the stream will be cancelable or not
+        params.transferable = true; // Whether the stream will be transferable or not
         params.startTime = uint40(block.timestamp + 100 seconds);
         params.broker = Broker(address(0), ud60x18(0)); // Optional parameter left undefined
 

--- a/v2/core/LockupLinearStreamCreator.sol
+++ b/v2/core/LockupLinearStreamCreator.sol
@@ -30,6 +30,7 @@ contract LockupLinearStreamCreator {
         params.totalAmount = totalAmount; // Total amount is the amount inclusive of all fees
         params.asset = DAI; // The streaming asset
         params.cancelable = true; // Whether the stream will be cancelable or not
+        params.transferable = true; // Whether the stream will be transferable or not
         params.durations = LockupLinear.Durations({
             cliff: 4 weeks, // Assets will be unlocked only after 4 weeks
             total: 52 weeks // Setting a total duration of ~1 year


### PR DESCRIPTION
There is `transferable` param in the [docs](https://docs.sablier.com/contracts/v2/guides/create-stream/lockup-linear#transferable), but not in the examples. 
See https://github.com/sablier-labs/docs/pull/148 before