### PR TITLE
fix: include caller check on hook calls

### DIFF
--- a/v2/core/RecipientHooks.sol
+++ b/v2/core/RecipientHooks.sol
@@ -4,6 +4,8 @@ pragma solidity >=0.8.19;
 import { ISablierV2LockupRecipient } from "@sablier/v2-core/src/interfaces/hooks/ISablierV2LockupRecipient.sol";
 
 abstract contract RecipientHooks is ISablierV2LockupRecipient {
+    error CallerNotSablierContract(address caller, address sablierContract);
+
     address public immutable sablierLockup;
 
     mapping(address => uint256) internal _balances;
@@ -31,7 +33,9 @@ abstract contract RecipientHooks is ISablierV2LockupRecipient {
     // Do something after a stream was renounced by the sender.
     function onStreamRenounced(uint256 streamId) external view {
         // Check: the caller is the lockup contract.
-        require(msg.sender == sablierLockup, "unauthorized");
+        if (msg.sender != sablierLockup) {
+            revert CallerNotSablierContract(msg.sender, sablierLockup);
+        }
 
         // Update the risk ratio.
         _updateRiskRatio({ nftId: streamId });
@@ -40,7 +44,9 @@ abstract contract RecipientHooks is ISablierV2LockupRecipient {
     // Do something after the sender or an NFT operator withdrew funds from a stream.
     function onStreamWithdrawn(uint256, /* streamId */ address caller, address, /* to */ uint128 amount) external {
         // Check: the caller is the lockup contract.
-        require(msg.sender == sablierLockup, "unauthorized");
+        if (msg.sender != sablierLockup) {
+            revert CallerNotSablierContract(msg.sender, sablierLockup);
+        }
 
         // Reduce the user's balance.
         _balances[caller] -= amount;

--- a/v2/core/RecipientHooks.sol
+++ b/v2/core/RecipientHooks.sol
@@ -4,7 +4,13 @@ pragma solidity >=0.8.19;
 import { ISablierV2LockupRecipient } from "@sablier/v2-core/src/interfaces/hooks/ISablierV2LockupRecipient.sol";
 
 abstract contract RecipientHooks is ISablierV2LockupRecipient {
+    address public immutable sablierLockup;
+
     mapping(address => uint256) internal _balances;
+
+    constructor(address sablierLockup_) {
+        sablierLockup = sablierLockup_;
+    }
 
     // Do something after a stream was canceled by the sender.
     function onStreamCanceled(
@@ -13,20 +19,29 @@ abstract contract RecipientHooks is ISablierV2LockupRecipient {
         uint128 /* recipientAmount */
     )
         external
-        pure
+        view
     {
+        // Check: the caller is the lockup contract.
+        require(msg.sender == sablierLockup, "unauthorized");
+
         // Liquidate the user's position.
         _liquidate({ nftId: streamId });
     }
 
     // Do something after a stream was renounced by the sender.
-    function onStreamRenounced(uint256 streamId) external pure {
+    function onStreamRenounced(uint256 streamId) external view {
+        // Check: the caller is the lockup contract.
+        require(msg.sender == sablierLockup, "unauthorized");
+
         // Update the risk ratio.
         _updateRiskRatio({ nftId: streamId });
     }
 
     // Do something after the sender or an NFT operator withdrew funds from a stream.
     function onStreamWithdrawn(uint256, /* streamId */ address caller, address, /* to */ uint128 amount) external {
+        // Check: the caller is the lockup contract.
+        require(msg.sender == sablierLockup, "unauthorized");
+
         // Reduce the user's balance.
         _balances[caller] -= amount;
     }


### PR DESCRIPTION
In the hook examples code, the check that caller must be the lockup instance is missing. This PR fixes that.

#### Some users are missing this check:
<img width="511" alt="Screenshot 2024-06-10 at 14 02 20" src="https://github.com/sablier-labs/examples/assets/6676622/eb3ed691-89f4-4d33-81da-0f383c1df42a">
