### PR TITLE
refactor: update examples with withdraw fees

### DIFF
--- a/flow/FlowStreamManager.sol
+++ b/flow/FlowStreamManager.sol
@@ -48,11 +48,13 @@ contract FlowStreamManager {
         FLOW.void(streamId);
     }
 
-    function withdraw(uint256 streamId) external {
-        FLOW.withdraw({ streamId: streamId, to: address(0xCAFE), amount: 2.71828e18 });
+    function withdraw(uint256 streamId) external payable {
+        uint256 fee = FLOW.calculateMinFeeWei(streamId);
+        FLOW.withdraw{ value: fee }({ streamId: streamId, to: address(0xCAFE), amount: 2.71828e18 });
     }
 
-    function withdrawMax(uint256 streamId) external {
-        FLOW.withdrawMax({ streamId: streamId, to: address(0xCAFE) });
+    function withdrawMax(uint256 streamId) external payable {
+        uint256 fee = FLOW.calculateMinFeeWei(streamId);
+        FLOW.withdrawMax{ value: fee }({ streamId: streamId, to: address(0xCAFE) });
     }
 }

--- a/lockup/StreamManagement.sol
+++ b/lockup/StreamManagement.sol
@@ -17,18 +17,30 @@ contract StreamManagement {
     //////////////////////////////////////////////////////////////////////////*/
 
     // This function can be called by the sender, recipient, or an approved NFT operator
-    function withdraw(uint256 streamId) external {
-        sablier.withdraw({ streamId: streamId, to: address(0xCAFE), amount: 1337e18 });
+    function withdraw(uint256 streamId) external payable {
+        uint256 fee = sablier.calculateMinFeeWei(streamId);
+        sablier.withdraw{ value: fee }({ streamId: streamId, to: address(0xCAFE), amount: 1337e18 });
     }
 
     // This function can be called by the sender, recipient, or an approved NFT operator
-    function withdrawMax(uint256 streamId) external {
-        sablier.withdrawMax({ streamId: streamId, to: address(0xCAFE) });
+    function withdrawMax(uint256 streamId) external payable {
+        uint256 fee = sablier.calculateMinFeeWei(streamId);
+        sablier.withdrawMax{ value: fee }({ streamId: streamId, to: address(0xCAFE) });
     }
 
     // This function can be called by either the recipient or an approved NFT operator
-    function withdrawMultiple(uint256[] calldata streamIds, uint128[] calldata amounts) external {
-        sablier.withdrawMultiple({ streamIds: streamIds, amounts: amounts });
+    function withdrawMultiple(uint256[] calldata streamIds, uint128[] calldata amounts) external payable {
+        uint256 maxFeeRequired;
+
+        // The fee required to call withdraw multiple is the maximum of the fees required to withdraw each stream.
+        for (uint256 i = 0; i < streamIds.length; i++) {
+            uint256 feeForStream = sablier.calculateMinFeeWei(streamIds[i]);
+            if (feeForStream > maxFeeRequired) {
+                maxFeeRequired = feeForStream;
+            }
+        }
+
+        sablier.withdrawMultiple{ value: maxFeeRequired }({ streamIds: streamIds, amounts: amounts });
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/lockup/StreamManagement.sol
+++ b/lockup/StreamManagement.sol
@@ -34,9 +34,9 @@ contract StreamManagement {
 
         // The fee required to call withdraw multiple is the maximum of the fees required to withdraw each stream.
         for (uint256 i = 0; i < streamIds.length; i++) {
-            uint256 feeForStream = sablier.calculateMinFeeWei(streamIds[i]);
-            if (feeForStream > maxFeeRequired) {
-                maxFeeRequired = feeForStream;
+            uint256 feeForStreamId = sablier.calculateMinFeeWei(streamIds[i]);
+            if (feeForStreamId > maxFeeRequired) {
+                maxFeeRequired = feeForStreamId;
             }
         }
 

--- a/lockup/StreamManagementWithHook.sol
+++ b/lockup/StreamManagementWithHook.sol
@@ -39,6 +39,7 @@ contract StreamManagementWithHook is ISablierLockupRecipient {
         SABLIER = sablier_;
         TOKEN = token_;
     }
+
     /*//////////////////////////////////////////////////////////////////////////
                                        CREATE
     //////////////////////////////////////////////////////////////////////////*/
@@ -87,15 +88,21 @@ contract StreamManagementWithHook is ISablierLockupRecipient {
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @dev This function can only be called by the stream beneficiary.
-    function withdraw(uint256 streamId, uint128 amount) external onlyStreamBeneficiary(streamId) {
+    function withdraw(uint256 streamId, uint128 amount) external payable onlyStreamBeneficiary(streamId) {
+        // Calculate the fee required to withdraw the amount.
+        uint256 fee = SABLIER.calculateMinFeeWei(streamId);
+
         // Withdraw the specified amount from the stream to the stream beneficiary.
-        SABLIER.withdraw({ streamId: streamId, to: streamBeneficiaries[streamId], amount: amount });
+        SABLIER.withdraw{ value: fee }({ streamId: streamId, to: streamBeneficiaries[streamId], amount: amount });
     }
 
     /// @dev This function can only be called by the stream beneficiary.
-    function withdrawMax(uint256 streamId) external onlyStreamBeneficiary(streamId) {
+    function withdrawMax(uint256 streamId) external payable onlyStreamBeneficiary(streamId) {
+        // Calculate the minimum fee to withdraw the amount.
+        uint256 fee = SABLIER.calculateMinFeeWei(streamId);
+
         // Withdraw the maximum amount from the stream to the stream beneficiary.
-        SABLIER.withdrawMax({ streamId: streamId, to: streamBeneficiaries[streamId] });
+        SABLIER.withdrawMax{ value: fee }({ streamId: streamId, to: streamBeneficiaries[streamId] });
     }
 
     /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We should provide examples of withdrawing from streams using `msg.value` fee.